### PR TITLE
38-flosystembash-bug-fix-check-nvme-connection-status

### DIFF
--- a/floSystem.bash
+++ b/floSystem.bash
@@ -7,5 +7,5 @@ echo "Pruning all stopped docker containers"
 docker container prune 
 echo "Starting flo_system container"
 # image=flosystem/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
-image = ohmnilabsvn/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
+image=ohmnilabsvn/ohmni_ros:ohmni_ros_tbcontrol_0.0.13
 docker run -it -d --name flo_system --network host --privileged -v /dev:/dev -v /var/dockerhome:/home/ohmnidev $image

--- a/floSystem.bash
+++ b/floSystem.bash
@@ -3,8 +3,9 @@ if test -f dev/block/sda1; then
   mkdir -p mnt/nvmeStorage
   mount dev/block/sda1 mnt/nvmeStorage
 fi
-echo "Pruning all stopped docker containers"
-docker container prune 
+#remove all stopped containers, along with any networks not used by at least one container, all dangling images, and all build cache. 
+echo "Pruning docker system"
+docker system prune
 echo "Starting flo_system container"
 # image=flosystem/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
 image=ohmnilabsvn/ohmni_ros:ohmni_ros_tbcontrol_0.0.13

--- a/floSystem.bash
+++ b/floSystem.bash
@@ -1,12 +1,15 @@
+echo "checking if external storage is connected"
 if test -f dev/block/sda1; then
   echo "Nvme Storage is connected, mounting at mnt/nvmeStorage"
   mkdir -p mnt/nvmeStorage
   mount dev/block/sda1 mnt/nvmeStorage
+else
+    echo "Nvme Storage is not connected"  
 fi
 #remove all stopped containers, along with any networks not used by at least one container, all dangling images, and all build cache. 
 echo "Pruning docker system"
-docker system prune
+docker system prune -f
 echo "Starting flo_system container"
-# image=flosystem/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
-image=ohmnilabsvn/ohmni_ros:ohmni_ros_tbcontrol_0.0.13
+# image=ohmnilabsvn/ohmni_ros:ohmni_ros_tbcontrol_0.0.13
+image=flosystem/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
 docker run -it -d --name flo_system --network host --privileged -v /dev:/dev -v /var/dockerhome:/home/ohmnidev $image

--- a/floSystem.bash
+++ b/floSystem.bash
@@ -1,4 +1,11 @@
-mkdir -p mnt/nvmeStorage
-mount dev/block/sda1 mnt/nvmeStorage
-image=flosystem/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
+if test -f dev/block/sda1; then
+  echo "Nvme Storage is connected, mounting at mnt/nvmeStorage"
+  mkdir -p mnt/nvmeStorage
+  mount dev/block/sda1 mnt/nvmeStorage
+fi
+echo "Pruning all stopped docker containers"
+docker container prune 
+echo "Starting flo_system container"
+# image=flosystem/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
+image = ohmnilabsvn/ohmni_ros:ohmni_ros_tbcontrol_0.0.13_mod
 docker run -it -d --name flo_system --network host --privileged -v /dev:/dev -v /var/dockerhome:/home/ohmnidev $image


### PR DESCRIPTION
added condition to check for presence of harddrive
added prune statements to prevent runaway usage of system resources and for better performance.
In future will have to change the docker image being used for the flo system, or rather change this whole script to run as part of a docker compose